### PR TITLE
refactor!: Use pure Rust rather than link to OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
+base64 = "0.21"
+rsa = { version = "0.9", features = ["sha1"] }
+sha1 = "0.10"
 thiserror = "1.0.24"

--- a/README.md
+++ b/README.md
@@ -1,24 +1,6 @@
 # AWS CloudFront Sign Utility
 Generating signed URLs for CloudFront links is a little more tricky than for S3. It's because signature generation for S3 URLs is handled a bit differently than CloudFront URLs. The Rusoto library is in maintenance mode and not accepting more features. Therefore we created this simple utility library to sign CloudFront URLs in Rust.
 
-## Requirements
-OpenSSL need to be installed. 
-
-```
-# macOS
-$ brew install openssl@1.1
-
-# Arch Linux
-$ sudo pacman -S pkg-config openssl
-
-# Debian and Ubuntu
-$ sudo apt-get install pkg-config libssl-dev
-
-# Fedora
-$ sudo dnf install pkg-config openssl-devel
-```
-
-
 ## Examples
 
 Getting signed cookies.


### PR DESCRIPTION
All the tests still pass, so this is at least equivalent to the previous content, but without the OpenSSL dependency.

BREAKING CHANGE: This changes the type of `EncodingError::InvalidKeyError` and adds another variant.