### PR TITLE
Remove unnecessary Expires parameter from custom policy signed URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,29 +173,16 @@ pub fn get_signed_url(url: &str, options: &SignedOptions) -> Result<String, Enco
     // policy is needed for signing but we do not have to include it into final url
     let policy = get_custom_policy(url, options);
     let signature = create_policy_signature(&policy, &options.private_key)?;
+    let policy_string = STANDARD.encode(policy.as_bytes());
 
-    if options.date_greater_than.is_some() || options.ip_address.is_some() {
-        let policy_string = STANDARD.encode(policy.as_bytes());
-
-        Ok(format!(
-            "{}{}Expires={}&Policy={}&Signature={}&Key-Pair-Id={}",
-            url,
-            separator,
-            options.date_less_than,
-            normalize_base64(&policy_string),
-            normalize_base64(&signature),
-            options.key_pair_id
-        ))
-    } else {
-        Ok(format!(
-            "{}{}Expires={}&Signature={}&Key-Pair-Id={}",
-            url,
-            separator,
-            options.date_less_than,
-            normalize_base64(&signature),
-            options.key_pair_id
-        ))
-    }
+    Ok(format!(
+        "{}{}Policy={}&Signature={}&Key-Pair-Id={}",
+        url,
+        separator,
+        normalize_base64(&policy_string),
+        normalize_base64(&signature),
+        options.key_pair_id
+    ))
 }
 
 #[cfg(test)]
@@ -267,7 +254,7 @@ mod tests {
             ..Default::default()
         };
         let signed_url = get_signed_url("https://example.com", &options).unwrap();
-        assert_eq!(signed_url, "https://example.com?Expires=200&Signature=Apw4PuuH0C5xnrZn8pU7JJk14JPRaNXLnJwmv6SL6RMC51qP2OxbYZxdDUyGW7-5EJ8hNIHObmaDlW0cUg6wocq1YOoqzMs1hFYTQbmhJc8wsjd~HCgiaI0oryb1oL~hDAQq22Ndl-5ue8OUeZxDJVFE0GAIpji~ubfmr2GV5ybEXQLWKWSh7k0wr5h27jt-QNDmQAlI3unPI5TiL3k9eZ-yl7G9jvzz3T3DsJgOb1TRqzyNx34smafA1En0dvrAAGRGbJVgD8vKDBJNnU8DqNho56w4Li2-pNLZHzfi2wa1gNb8-Dg5rpqBtpO0sf6d4gOD1oQYRRuYHYOBm7T4zw__&Key-Pair-Id=SOMEKEYPAIRID");
+        assert_eq!(signed_url, "https://example.com?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MjAwfX19XX0_&Signature=Apw4PuuH0C5xnrZn8pU7JJk14JPRaNXLnJwmv6SL6RMC51qP2OxbYZxdDUyGW7-5EJ8hNIHObmaDlW0cUg6wocq1YOoqzMs1hFYTQbmhJc8wsjd~HCgiaI0oryb1oL~hDAQq22Ndl-5ue8OUeZxDJVFE0GAIpji~ubfmr2GV5ybEXQLWKWSh7k0wr5h27jt-QNDmQAlI3unPI5TiL3k9eZ-yl7G9jvzz3T3DsJgOb1TRqzyNx34smafA1En0dvrAAGRGbJVgD8vKDBJNnU8DqNho56w4Li2-pNLZHzfi2wa1gNb8-Dg5rpqBtpO0sf6d4gOD1oQYRRuYHYOBm7T4zw__&Key-Pair-Id=SOMEKEYPAIRID");
     }
 
     #[test]
@@ -281,7 +268,7 @@ mod tests {
             ..Default::default()
         };
         let signed_url = get_signed_url("https://example.com?a=b", &options).unwrap();
-        assert_eq!(signed_url, "https://example.com?a=b&Expires=200&Signature=qGmt6kxwZVt6kjJWhDQlUr6Q71dkd7JrWb9x1Von71pTNA-WzHbgjd3FpqyEvugBm37aacqtYLsuHG75AkFyqA2ndQtRDpQEE0MAylbnZMI7o~wWVFs4WjvFmwP~-ZazTFnnMRp7tBA1g0If4BDi39EHYQlHIyQNf3GmQp0yD~tpgfbSANr8fqiJDNzB7GmQTgeBvNjnwKOB0h3CwptAYDfieRDyJxS5vFARGBGdXlPHVA0M7SYlxdYPieRp58XAuTY6jtWO5VC3~3beUM~J-DgQ6uXqGCahoxFOhK2QpcBGgKHFBnknzsbXMerEeQpLx4J77Ky1-LGi6lC0o4mqNQ__&Key-Pair-Id=SOMEKEYPAIRID");
+        assert_eq!(signed_url, "https://example.com?a=b&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9hPWIiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjIwMH19fV19&Signature=qGmt6kxwZVt6kjJWhDQlUr6Q71dkd7JrWb9x1Von71pTNA-WzHbgjd3FpqyEvugBm37aacqtYLsuHG75AkFyqA2ndQtRDpQEE0MAylbnZMI7o~wWVFs4WjvFmwP~-ZazTFnnMRp7tBA1g0If4BDi39EHYQlHIyQNf3GmQp0yD~tpgfbSANr8fqiJDNzB7GmQTgeBvNjnwKOB0h3CwptAYDfieRDyJxS5vFARGBGdXlPHVA0M7SYlxdYPieRp58XAuTY6jtWO5VC3~3beUM~J-DgQ6uXqGCahoxFOhK2QpcBGgKHFBnknzsbXMerEeQpLx4J77Ky1-LGi6lC0o4mqNQ__&Key-Pair-Id=SOMEKEYPAIRID");
     }
 
     #[test]
@@ -313,7 +300,7 @@ mod tests {
         };
         let signed_url =
             get_signed_url("https://test.example.com/test/data?a=b", &options).unwrap();
-        assert_eq!(signed_url, "https://test.example.com/test/data?a=b&Expires=200&Signature=M5iuyWSnPX0A79jCT8tlbEQoLlQL8WSTAPeZb8mHhIVwhJvW7HRgl3r~ZNLg8~g7YcYn683vZ7-9sBcU3FYCDVY~fUgoC-i5xth7wCYGQ9xCxjaUiQlM6N~NfU8dN0Qj-hNZasZN6IKDE3e9dwaUZ9E5MHCPyN~L3fPYwfm6KWsrNXbE4udWdkjzj1mjE5YvMzAWUnwe7Z6MciuZX~LT8u95OEsWA1ZXbyxhpPIDs2SXB07oKC0x~5HncpOMzTglFGmSoGMVytJtE2N3jgS4ecEJQ9d9vzYKlCfR1RH8N~aw0TC4pVG4~R9i2qzGGt53DBJxdrecQOdcSdwwy8grOg__&Key-Pair-Id=SOMEKEYPAIRID");
+        assert_eq!(signed_url, "https://test.example.com/test/data?a=b&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly8qLmV4YW1wbGUuY29tL3Rlc3QvKiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MjAwfX19XX0_&Signature=M5iuyWSnPX0A79jCT8tlbEQoLlQL8WSTAPeZb8mHhIVwhJvW7HRgl3r~ZNLg8~g7YcYn683vZ7-9sBcU3FYCDVY~fUgoC-i5xth7wCYGQ9xCxjaUiQlM6N~NfU8dN0Qj-hNZasZN6IKDE3e9dwaUZ9E5MHCPyN~L3fPYwfm6KWsrNXbE4udWdkjzj1mjE5YvMzAWUnwe7Z6MciuZX~LT8u95OEsWA1ZXbyxhpPIDs2SXB07oKC0x~5HncpOMzTglFGmSoGMVytJtE2N3jgS4ecEJQ9d9vzYKlCfR1RH8N~aw0TC4pVG4~R9i2qzGGt53DBJxdrecQOdcSdwwy8grOg__&Key-Pair-Id=SOMEKEYPAIRID");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixed an issue where the Expires parameter was incorrectly included in signed URLs using custom policy.

## Changes

- Use custom policy consistently for signed URL generation
- Remove Expires parameter from signed URL (not needed when using custom policy)